### PR TITLE
Handle case when user doesn't select any option

### DIFF
--- a/commands/core/delete.sh
+++ b/commands/core/delete.sh
@@ -41,6 +41,11 @@ function dx::delete() {
 
     local -r row="$(echo -e "${resources}" | fzf)"
 
+    if [ -z "${row}" ]; then
+      # User does not select any option
+      exit 0
+    fi
+
     local -r type="$(echo "${row}" | awk '{ print $1 }')"
     local -r id="$(echo "${row}" | awk '{ print $2 }')"
     local -r description="$(echo "${row}" | awk '{ print $3 }')"


### PR DESCRIPTION
Currently, a prompt with a warning will be shown asking if the user wants to delete selected resources, but no resources were chosen.

With these changes, no prompt will be shown.